### PR TITLE
Feature/base64 encode coins

### DIFF
--- a/wasm/internal/common.go
+++ b/wasm/internal/common.go
@@ -78,7 +78,7 @@ func EstimateProofSize(numIn, numOut uint64) uint64{
 	return toB64Len(result)
 }
 
-func EstimateTxSize(estimateTxSizeParam *EstimateTxSizeParam) uint64{
+func estimateTxSizeAsBytes(estimateTxSizeParam *EstimateTxSizeParam) uint64{
 	// jsb, _ := json.Marshal(estimateTxSizeParam)
 	// println("PARAMS", string(jsb))
 	jsonKeysSizeBound := uint64(20 * 10 + 2)

--- a/wasm/internal/common/constants.go
+++ b/wasm/internal/common/constants.go
@@ -14,6 +14,7 @@ const (
 	HashSize          = 32 // bytes
 	MaxHashStringSize = HashSize * 2
 	Base58Version     = 0
+	EncodeCoinsWithBase64 = false
 )
 
 // size data for incognito key and signature

--- a/wasm/internal/exports.go
+++ b/wasm/internal/exports.go
@@ -471,7 +471,7 @@ func VerifySign(args string) (bool, error){
 	return res, nil
 }
 
-func EstimateTxSizeInKB(paramStr string) (int64, error){
+func EstimateTxSize(paramStr string) (int64, error){
 	var err error
 	temp := &EstimateTxSizeParam{}
 	err = json.Unmarshal([]byte(paramStr), temp)
@@ -479,7 +479,7 @@ func EstimateTxSizeInKB(paramStr string) (int64, error){
 		return -1, err
 	}
 
-	size := EstimateTxSize(temp)
+	size := estimateTxSizeAsBytes(temp)
 	result := int64(math.Ceil(float64(size) / 1024))
 	return result, nil
 }

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -42,7 +42,7 @@ func main() {
 	gobridge.RegisterCallback("withdrawDexTx", internal.CreateTransaction)
 	gobridge.RegisterCallback("hybridEncryptionASM", internal.HybridEncrypt)
 	gobridge.RegisterCallback("hybridDecryptionASM", internal.HybridDecrypt)
-	gobridge.RegisterCallback("estimateTxSize", internal.EstimateTxSizeInKB)
+	gobridge.RegisterCallback("estimateTxSize", internal.EstimateTxSize)
 	// not applicable
 	// gobridge.RegisterCallback("deriveSerialNumber", internal.DeriveSerialNumber)
 


### PR DESCRIPTION
- add a toggle for base64/base58 encoding for fields in output coins
- update exported name for estimateTxSize